### PR TITLE
Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Generally the [wiki](https://codeberg.org/flohmarkt/flohmarkt/wiki) is a good so
 * [Service compatibility chart](https://codeberg.org/flohmarkt/flohmarkt/wiki/Service-compatibility-chart)
 
 
-**Shipped version:** 0.6.1~ynh1
+**Shipped version:** 0.6.1~ynh3
 
 **Demo:** <https://flohmarkt.ween.de/>
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -55,7 +55,7 @@ Generally the [wiki](https://codeberg.org/flohmarkt/flohmarkt/wiki) is a good so
 * [Service compatibility chart](https://codeberg.org/flohmarkt/flohmarkt/wiki/Service-compatibility-chart)
 
 
-**Paketatutako bertsioa:** 0.6.1~ynh1
+**Paketatutako bertsioa:** 0.6.1~ynh3
 
 **Demoa:** <https://flohmarkt.ween.de/>
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -55,7 +55,7 @@ Generally the [wiki](https://codeberg.org/flohmarkt/flohmarkt/wiki) is a good so
 * [Service compatibility chart](https://codeberg.org/flohmarkt/flohmarkt/wiki/Service-compatibility-chart)
 
 
-**Version incluse :** 0.6.1~ynh1
+**Version incluse :** 0.6.1~ynh3
 
 **Démo :** <https://flohmarkt.ween.de/>
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -55,7 +55,7 @@ Generally the [wiki](https://codeberg.org/flohmarkt/flohmarkt/wiki) is a good so
 * [Service compatibility chart](https://codeberg.org/flohmarkt/flohmarkt/wiki/Service-compatibility-chart)
 
 
-**Versión proporcionada:** 0.6.1~ynh1
+**Versión proporcionada:** 0.6.1~ynh3
 
 **Demo:** <https://flohmarkt.ween.de/>
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -55,7 +55,7 @@ Generally the [wiki](https://codeberg.org/flohmarkt/flohmarkt/wiki) is a good so
 * [Service compatibility chart](https://codeberg.org/flohmarkt/flohmarkt/wiki/Service-compatibility-chart)
 
 
-**分发版本：** 0.6.1~ynh1
+**分发版本：** 0.6.1~ynh3
 
 **演示：** <https://flohmarkt.ween.de/>
 

--- a/conf/urlwatch_urls.yaml
+++ b/conf/urlwatch_urls.yaml
@@ -1,6 +1,6 @@
 name: "watch for changes in user database"
 kind: "url"
-url: "http://__APP__:__PASSWORD_COUCHDB_FLOHMARKT__@127.0.0.1:5984/flohmarkt/_find"
+url: "http://__APP__:__PASSWORD_COUCHDB_FLOHMARKT__@127.0.0.1:5984/__APP__/_find"
 method: "POST"
 data: '{"selector": { "role": "User", "name": { "$ne": "instance" }}, 
   "fields": ["name","email","active"], "sort": [ "name" ]}'

--- a/doc/PRE_UPGRADE.md
+++ b/doc/PRE_UPGRADE.md
@@ -1,3 +1,9 @@
+# new in 0.6.1~ynh2
+
+No new features.
+
+Fixed a bug in the generation of the urlwatch configuration: on yunohosts with mulitple flohmarkt installations the second and any further installation used a wrong url path to access flohmarkts couchdb.
+
 # new in 0.6.1~ynh1
 
 ## new features

--- a/manifest.toml
+++ b/manifest.toml
@@ -26,7 +26,7 @@ code = "https://codeberg.org/flohmarkt/flohmarkt"
 # fund = "???"
 
 [integration]
-yunohost = ">= 12.0.10"
+yunohost = ">= 12.0.9"
 architectures = "all"
 # https://codeberg.org/ChriChri/flohmarkt_ynh/issues/11
 multi_instance = true

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "flohmarkt"
 description.en = "A decentral federated small ads platform"
 description.fr = "Plateforme de petites annonces fédérées décentralisées"
 
-version = "0.6.1~ynh1"
+version = "0.6.1~ynh3"
 
 maintainers = ["Chris Vogel"]
 
@@ -26,7 +26,7 @@ code = "https://codeberg.org/flohmarkt/flohmarkt"
 # fund = "???"
 
 [integration]
-yunohost = ">= 11.2.11"
+yunohost = ">= 12.0.10"
 architectures = "all"
 # https://codeberg.org/ChriChri/flohmarkt_ynh/issues/11
 multi_instance = true


### PR DESCRIPTION
Fixed a bug in the generation of the urlwatch configuration: on yunohosts with mulitple flohmarkt installations the second and any further installation used a wrong url path to access flohmarkts couchdb.