### PR TITLE
Update install, check is urlwatch is installed, if not, install

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -123,6 +123,13 @@ ynh_script_progression --message="Starting flohmarkt..." --weight=10
 flohmarkt_ynh_start_service
 
 # integrate urlwatch
+ynh_script_progression --message="Install urlwatch..." --weight=1
+if ynh_package_is_installed --package=urlwatch;
+then
+  ynh_script_progression --message="urlwatch already installed. Skipping." --weight=1
+else
+  ynh_install_app_dependencies urlwatch
+fi
 ynh_script_progression --message="Configure urlwatch and its cron job..." --weight=1
 flohmarkt_ynh_urlwatch_cron
 


### PR DESCRIPTION
My hourly cron spammed a lot because urlwatch was not installed. I tried to fix that with this lines.

**First time commit to YunoHost package and unchecked!**