### PR TITLE
Flohmarkt [Hosting] section

### DIFF
--- a/conf/flohmarkt.conf
+++ b/conf/flohmarkt.conf
@@ -5,6 +5,11 @@ HttpsNoVerifyCert = 0
 JwtSecret = __JWTSECRET__
 DataPath = __DATA_DIR__
 
+[Hosting]
+# Information about the hosting environment (appears in nodeinfo metadata)
+Provider = yunohost
+ProviderVersion = __YNH_PACKAGE_VERSION__
+
 [Database]
 UseHttps = 0
 Host = 127.0.0.1

--- a/scripts/install
+++ b/scripts/install
@@ -76,6 +76,7 @@ ynh_app_setting_set --app=$app --key=password_couchdb_flohmarkt --value="$passwo
 
 # generate flohmarkt.conf
 ynh_script_progression --message="Adding flohmarkt.conf configuration..." --weight=2
+ynh_package_version="$YNH_APP_MANIFEST_VERSION"
 ynh_add_config --template="../conf/flohmarkt.conf" --destination="$flohmarkt_app_dir/flohmarkt.conf"
 
 # setup couchdb

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -64,6 +64,7 @@ flohmarkt_ynh_venv_requirements
 
 # upgrade flohmarkt.conf
 ynh_script_progression --message="Upgrading flohmarkt configuration..." --weight=1
+ynh_package_version="$YNH_APP_MANIFEST_VERSION"
 ynh_add_config --template="../conf/flohmarkt.conf" --destination="$flohmarkt_app_dir/flohmarkt.conf"
 
 ynh_script_progression --message="Upgrading flohmarkt couchdb..." --weight=10


### PR DESCRIPTION
Attention: the upstream PR is not yet merged, this is just an idea of how we could integrate it.
I did not test it, because I don’t have a yunohost setup, so the version templating might not work as I did it here.

In https://codeberg.org/flohmarkt/flohmarkt/pulls/739 we add a [Hosting] section to the flohmarkt conf, with which instance admins can add info about how their flohmarkt is hosted, so that we can figure out how people prefer to host. This would let us determine how many actual instances are hosted via yunohost and what yunohost versions they are on.
